### PR TITLE
Using lodash-es to enable splitting of lodash modules.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.1.0",
 			"license": "MIT",
 			"dependencies": {
-				"lodash": "^4.17.21"
+				"lodash-es": "^4.17.21"
 			},
 			"devDependencies": {
 				"@babel/core": "^7.26.10",
@@ -23,7 +23,7 @@
 				"@rollup/plugin-terser": "^0.4.4",
 				"@tsconfig/svelte": "^5.0.4",
 				"@types/firefox-webext-browser": "^120.0.4",
-				"@types/lodash": "^4.17.12",
+				"@types/lodash-es": "^4.17.12",
 				"babel-plugin-lodash": "^3.3.4",
 				"esbuild": "^0.25.1",
 				"hex-to-css-filter": "^6.0.0",
@@ -2659,6 +2659,16 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/lodash-es": {
+			"version": "4.17.12",
+			"resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
+			"integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/lodash": "*"
+			}
+		},
 		"node_modules/@types/minimatch": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
@@ -3568,6 +3578,13 @@
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
 			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/lodash-es": {
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+			"integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
 			"license": "MIT"
 		},
 		"node_modules/lodash.debounce": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"@rollup/plugin-terser": "^0.4.4",
 		"@tsconfig/svelte": "^5.0.4",
 		"@types/firefox-webext-browser": "^120.0.4",
-		"@types/lodash": "^4.17.12",
+		"@types/lodash-es": "^4.17.12",
 		"babel-plugin-lodash": "^3.3.4",
 		"esbuild": "^0.25.1",
 		"hex-to-css-filter": "^6.0.0",
@@ -47,6 +47,6 @@
 	},
 	"homepage": "https://github.com/arpitchakladar/better-containers#readme",
 	"dependencies": {
-		"lodash": "^4.17.21"
+		"lodash-es": "^4.17.21"
 	}
 }

--- a/src/background/container.ts
+++ b/src/background/container.ts
@@ -1,4 +1,4 @@
-import _ from "lodash";
+import * as _ from "lodash-es";
 import {
 	DEFAULT_CONTAINER,
 	openTabInContainer,

--- a/src/background/cookies.ts
+++ b/src/background/cookies.ts
@@ -1,4 +1,4 @@
-import _ from "lodash";
+import * as _ from "lodash-es";
 import { DEFAULT_CONTAINER } from "@/utils/containers";
 import { removeCookie } from "@/utils/cookies";
 import { type ContainerConfiguration } from "@/utils/storage";

--- a/src/components/VerticalList.svelte
+++ b/src/components/VerticalList.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import _ from "lodash";
+	import * as _ from "lodash-es";
 	import Button from "@/components/Button.svelte";
 	import SingleInputForm from "@/components/SingleInputForm.svelte";
 

--- a/src/pages/configuration/ContainerConfiguration.svelte
+++ b/src/pages/configuration/ContainerConfiguration.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import _ from "lodash";
+	import * as _ from "lodash-es";
 	import { onMount } from "svelte";
 	import { hexToCSSFilter } from "hex-to-css-filter";
 	import { navigate } from "@/pages/configuration/pageStore";

--- a/src/pages/configuration/SiteConfiguration.svelte
+++ b/src/pages/configuration/SiteConfiguration.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import _ from "lodash";
+	import * as _ from "lodash-es";
 	import { onMount } from "svelte";
 	import { navigate } from "@/pages/configuration/pageStore";
 	import { toggleContainerForSite } from "@/utils/storage";

--- a/src/pages/select-container/SelectContainer.svelte
+++ b/src/pages/select-container/SelectContainer.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import _ from "lodash";
+	import * as _ from "lodash-es";
 	import LoadingContainersList from "@/components/LoadingContainersList.svelte";
 
 	const params = new URLSearchParams(window.location.search);

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,4 +1,4 @@
-import _ from "lodash";
+import * as _ from "lodash-es";
 
 export interface ContainerConfiguration {
 	sites: string[];


### PR DESCRIPTION
Using lodash-es with babel-lodash-plugin results in smaller bundles as it splits the individual functions into its own modules.